### PR TITLE
Add Content option to upload client

### DIFF
--- a/src/JetBrains.Space.Client/Extensions/UploadClient.cs
+++ b/src/JetBrains.Space.Client/Extensions/UploadClient.cs
@@ -37,13 +37,45 @@ public partial class UploadClient
         HttpClient? httpClient = null,
         CancellationToken cancellationToken = default)
     {
+        return await UploadAsync(
+            storagePrefix,
+            fileName,
+            new StreamContent(uploadStream),
+            mediaType,
+            httpClient,
+            cancellationToken
+        );
+    }
+
+    /// <summary>
+    /// Upload an attachment to Space. Wrapper method over <see cref="CreateUploadAsync"/>.
+    /// </summary>
+    /// <remarks>
+    /// Make sure the <paramref name="uploadStream"/> has its position set to 0. The Space SDK uses the stream as-is, and will not rewind or dispose the stream.
+    /// </remarks>
+    /// <param name="storagePrefix">Storage prefix. See <see cref="CreateUploadAsync"/> for supported values.</param>
+    /// <param name="fileName">File name, e.g. 'image.png'.</param>
+    /// <param name="httpContent"><see cref="HttpContent"/> to upload. The content is used as-is, and will not be rewound or disposed.</param>
+    /// <param name="mediaType">Media type. See <see cref="CreateUploadAsync"/> for supported values.</param>
+    /// <param name="httpClient"><see cref="HttpClient"/> instance to use for uploading the stream. Defaults to <see cref="SharedHttpClient.Instance"/>.</param>
+    /// <param name="cancellationToken">Cancellation token to abort the upload.</param>
+    /// <returns>The upload identifier, e.g. `yjojA0f1Jiv`. This usually can be accessed from the server at `/d/yjojA0f1Jiv`.</returns>
+    /// <exception cref="ResourceException">Exception when uploading the stream fails.</exception>
+    public async Task<string?> UploadAsync(
+        string storagePrefix,
+        string fileName,
+        HttpContent httpContent,
+        string? mediaType = null,
+        HttpClient? httpClient = null,
+        CancellationToken cancellationToken = default)
+    {
         var uploadHttpClient = httpClient ?? SharedHttpClient.Instance;
             
         var uploadPath = await CreateUploadAsync(storagePrefix, mediaType, null, cancellationToken);
 
         var request = new HttpRequestMessage(HttpMethod.Put, _connection.ServerUrl + uploadPath.TrimStart('/') + "/" + fileName.TrimStart('/'))
         {
-            Content = new StreamContent(uploadStream)
+            Content = httpContent
         }.WithClientAndSdkHeaders(SdkInfo.Version);
             
         var response = await uploadHttpClient.SendAsync(request, cancellationToken);


### PR DESCRIPTION
If we want to provide a custom content-type, we need to specify it on the `HttpContent`. Instead of exposing that parameter, just added an overload that allows providing any content to the upload request.
Example usage of such custom content:

```cs
new StreamContent(_uploadStream)
 {
     Headers = { ContentType = new MediaTypeHeaderValue("image/gif") }
 };
```

This is needed for example to upload emojis. The current behavior uses stream content-type, which is then forbidden to be used as an image by Space.